### PR TITLE
docs(arcade): integrate mastery docs and exclusion decisions

### DIFF
--- a/docs/GET_STARTED.md
+++ b/docs/GET_STARTED.md
@@ -96,6 +96,8 @@ If the stream is also live through `555 Stream`, stop the stream from that plugi
 
 ## Next docs
 
+- `PROGRAM_INDEX.md`
 - `INSTALL_AND_AUTH.md`
 - `ACTIONS_REFERENCE.md`
 - `EDGE_CASES_AND_RECOVERY.md`
+- `MASTERY_INDEX.md`

--- a/docs/MASTERY_EXCLUSION_DECISIONS.md
+++ b/docs/MASTERY_EXCLUSION_DECISIONS.md
@@ -1,0 +1,45 @@
+# 555 Arcade Mastery Exclusion Decisions
+
+This document makes the current non-dossier decisions explicit for the remaining
+public-catalog gaps. These are documentation and claim-boundary decisions, not
+claims that the games are removed from the catalog.
+
+## 555 Lottery
+
+- current decision: exclude from the mastery-claim set
+- reason: lottery-style play does not yet have a documented mastery surface in
+  this repo that matches the same game-specific standard as the authored
+  dossiers
+- reopen condition: add a dedicated operator/mastery dossier that explains the
+  player loop, state changes, scoring or outcome logic, and operator-facing
+  boundaries
+
+## Flock
+
+- current decision: exclude from the mastery-claim set
+- reason: no dedicated mastery dossier currently exists in the repo for the
+  public-catalog entry
+- reopen condition: add a dossier that matches the standard used for the
+  existing 16 authored games
+
+## Dr1v3n Wild
+
+- current decision: exclude from the mastery-claim set
+- reason: the repo does not yet have a dedicated mastery dossier for this
+  public-catalog entry
+- reopen condition: add a dossier with the same coverage bar as the existing
+  mastery set
+
+## Pixel Copter
+
+- current decision: exclude from the mastery-claim set
+- reason: the public-catalog entry is not yet backed by a dedicated dossier in
+  this repo
+- reopen condition: add a dedicated dossier and link it from
+  `MASTERY_INDEX.md`
+
+## Claim rule
+
+- The public catalog may say these games exist.
+- The public catalog may not say these games are part of the mastered dossier
+  set until their reopen condition is satisfied.

--- a/docs/MASTERY_INDEX.md
+++ b/docs/MASTERY_INDEX.md
@@ -1,0 +1,41 @@
+# 555 Arcade Mastery Index
+
+This index tracks the full 20-game mastery target against the currently
+authored dossier set.
+
+## Existing mastery dossiers
+
+| Game | Dossier |
+| --- | --- |
+| 555 Drive | `../src/mastery/dossiers/555drive.md` |
+| Chess Pursuit | `../src/mastery/dossiers/chesspursuit.md` |
+| Clawstrike | `../src/mastery/dossiers/clawstrike.md` |
+| Eat My Dust | `../src/mastery/dossiers/eat-my-dust.md` |
+| Fighter Planes | `../src/mastery/dossiers/fighter-planes.md` |
+| Floor 13 | `../src/mastery/dossiers/floor13.md` |
+| Godai Is Back | `../src/mastery/dossiers/godai-is-back.md` |
+| Knighthood | `../src/mastery/dossiers/knighthood.md` |
+| Left and Right | `../src/mastery/dossiers/leftandright.md` |
+| Ninja vs EvilCorp | `../src/mastery/dossiers/ninja.md` |
+| Peanball | `../src/mastery/dossiers/peanball.md` |
+| Playback | `../src/mastery/dossiers/playback.md` |
+| Sector 13 | `../src/mastery/dossiers/sector-13.md` |
+| Vedas Run | `../src/mastery/dossiers/vedas-run.md` |
+| Where We're Going We Do Need Roads | `../src/mastery/dossiers/where-were-going-we-do-need-roads.md` |
+| Wolf and Sheep | `../src/mastery/dossiers/wolf-and-sheep.md` |
+
+## Missing public-catalog mastery coverage
+
+These public-catalog games do not yet have a dedicated mastery dossier in this
+repo and should remain explicitly open until they do:
+
+- 555 Lottery
+- Flock
+- Dr1v3n Wild
+- Pixel Copter
+
+## Operating rule
+
+- The public catalog can only claim full mastery coverage once all 20 games have
+  a dossier or an explicit exclusion decision.
+- If a game is playable but not yet mastered, say so plainly.

--- a/docs/MASTERY_INDEX.md
+++ b/docs/MASTERY_INDEX.md
@@ -24,10 +24,14 @@ authored dossier set.
 | Where We're Going We Do Need Roads | `../src/mastery/dossiers/where-were-going-we-do-need-roads.md` |
 | Wolf and Sheep | `../src/mastery/dossiers/wolf-and-sheep.md` |
 
-## Missing public-catalog mastery coverage
+## Public-catalog gap decisions
 
-These public-catalog games do not yet have a dedicated mastery dossier in this
-repo and should remain explicitly open until they do:
+The remaining public-catalog gaps are now tracked in
+`MASTERY_EXCLUSION_DECISIONS.md`.
+
+The catalog can only claim full mastery coverage once each of these games has
+either a dedicated dossier or an explicit decision that keeps it out of the
+mastery-claim set:
 
 - 555 Lottery
 - Flock

--- a/docs/PROGRAM_INDEX.md
+++ b/docs/PROGRAM_INDEX.md
@@ -1,0 +1,34 @@
+# 555 Arcade Program Index
+
+This is the canonical docs index for the arcade operator program.
+
+Use it to traverse integration, gameplay, progression, mastery, proof, and
+release material without guessing which packet is current.
+
+## Core operator path
+
+1. `GET_STARTED.md`
+2. `INSTALL_AND_AUTH.md`
+3. `OPERATOR_SETUP_MATRIX.md`
+4. `ACTIONS_REFERENCE.md`
+5. `COMPLEX_FLOWS.md`
+6. `EDGE_CASES_AND_RECOVERY.md`
+7. `STATES_AND_TRANSITIONS.md`
+
+## Progression and mastery
+
+- `PROGRESSION_AND_ADMIN_EXAMPLES.md`
+- `MASTERY_INDEX.md`
+- `src/mastery/dossiers/`
+
+## Release and proof
+
+- `PUBLIC_RELEASE_CHECKLIST.md`
+- `COVERAGE_AND_GAPS.md`
+- `WIP_TODO.md`
+- `handoffs/ATOMIC_MASTERY_HANDOFF_2026-03-08.md`
+
+## Rule
+
+Gameplay truth lives in the operator docs and mastery dossiers. Public-facing
+summary docs can compress this material, but they should not replace it.

--- a/docs/PROGRESSION_AND_ADMIN_EXAMPLES.md
+++ b/docs/PROGRESSION_AND_ADMIN_EXAMPLES.md
@@ -1,0 +1,127 @@
+# Progression And Admin Examples
+
+Use this document when you need concrete examples for the progression and
+advanced/admin surfaces that sit beyond the default play loop.
+
+## Default operator flow
+
+Default operator flow should remain:
+
+1. bootstrap session
+2. fetch catalog
+3. start or switch game
+4. read score and leaderboard state
+5. stop safely
+
+This is the path to teach first.
+
+## Progression examples
+
+### Example 1: Read score after a run
+
+Action:
+- `ARCADE555_SCORE_READ`
+
+Typical inputs:
+- `gameId`
+- `sessionId`
+- optional `runId`
+
+Use when:
+- a run just ended
+- an operator needs to confirm whether a score synced
+- support needs to inspect one specific play session
+
+### Example 2: Submit score when the flow requires explicit submission
+
+Action:
+- `ARCADE555_SCORE_SUBMIT`
+
+Typical inputs:
+- `gameId`
+- `sessionId`
+- score or outcome payload expected by the current game/runtime contract
+
+Use when:
+- the current title does not auto-sync a result
+- the operator is closing a bounded run and needs the canonical record written
+
+### Example 3: Read leaderboard and quest state without mutating anything
+
+Actions:
+- `ARCADE555_LEADERBOARD_READ`
+- `ARCADE555_QUESTS_READ`
+
+Typical uses:
+- confirm whether a score changed rank
+- explain current progression state to a player
+- confirm quest eligibility before using any admin surface
+
+## Recommended progression sequence
+
+1. `ARCADE555_SCORE_READ`
+2. `ARCADE555_LEADERBOARD_READ`
+3. `ARCADE555_QUESTS_READ`
+4. `ARCADE555_SCORE_SUBMIT` only when the game/runtime requires an explicit
+   write
+
+The operator should exhaust the read path before using a write path.
+
+## Advanced/admin guidance
+
+Advanced and admin actions should be introduced only after the default operator
+path is stable.
+
+### Example 4: Manage session continuity across a game switch
+
+Actions:
+- `ARCADE555_GAMES_SWITCH`
+- `ARCADE555_SCORE_READ`
+
+Use when:
+- one operator session spans more than one title
+- the next title should inherit the current live/operator context
+
+Check after the switch:
+- the new `gameId` is active
+- the prior game's score state is settled
+- leaderboard reads still resolve against the intended game
+
+### Example 5: Work a battle or reward path
+
+Actions:
+- `ARCADE555_BATTLES_CREATE`
+- `ARCADE555_BATTLES_RESOLVE`
+- `ARCADE555_REWARDS_PROJECT`
+- `ARCADE555_REWARDS_ALLOCATE`
+
+Use when:
+- the flow is no longer simple single-player progression
+- the operator is running a competitive or rewards-backed event
+
+Rule:
+- do not introduce these actions into beginner docs
+- always pair them with the recovery/cleanup expectation for the event
+
+### Example 6: Use admin-only intervention surfaces
+
+Actions:
+- `ARCADE555_THEME_SET`
+- `ARCADE555_EVENT_TRIGGER`
+- `ARCADE555_CABINET_POSSESS`
+- `ARCADE555_CABINET_RELEASE`
+
+Use when:
+- the default public flow cannot recover itself
+- an event, theme, or cabinet state needs operator intervention
+
+Admin rule:
+- explain why the intervention is needed
+- confirm the platform returns to the normal default flow afterward
+
+## Documentation rule
+
+- beginner/operator docs teach the default flow
+- advanced/admin docs teach exceptions, intervention, and recovery
+- do not collapse both layers into one checklist
+- if an example requires a non-GA or advanced action, label it as advanced

--- a/docs/handoffs/ATOMIC_MASTERY_HANDOFF_2026-03-08.md
+++ b/docs/handoffs/ATOMIC_MASTERY_HANDOFF_2026-03-08.md
@@ -1,0 +1,73 @@
+# Atomic Mastery Handoff 2026-03-08
+
+## 1. Effective Branch And Exact Local Head Commit
+
+- Effective branch: `main`
+- Local head commit: `856a0e4`
+- PR branch: `codex/pr-atomic-mastery-handoff-arcade-plugin-20260308`
+
+## 2. Exact Commits Included In The Handoff
+
+- `856a0e4` `feat: add atomic mastery audit framework and dossiers`
+
+## 3. Retained Value Shipped In This Repo
+
+- Atomic audit framework was added to mastery types and shared contract structure:
+  - [types.ts](/Volumes/OWC%20Envoy%20Pro%20FX/desktop_dump/new/Work/555/arcade-plugin/src/mastery/types.ts)
+  - [_shared.ts](/Volumes/OWC%20Envoy%20Pro%20FX/desktop_dump/new/Work/555/arcade-plugin/src/mastery/contracts/_shared.ts)
+  - [index.ts](/Volumes/OWC%20Envoy%20Pro%20FX/desktop_dump/new/Work/555/arcade-plugin/src/mastery/index.ts)
+- Cohort 1 source-truth audits were added for:
+  - `playback`
+  - `floor13`
+  - `chesspursuit`
+  - `vedas-run`
+- Cohort 2 source-truth audits were added for:
+  - `ninja`
+  - `leftandright`
+  - `clawstrike`
+  - `where-were-going-we-do-need-roads`
+- Mastery activity and telemetry helpers were added to the active root package.
+
+## 4. Non-Retained Experiments Explicitly Excluded From This Repo
+
+- Contracts describe blockers and controller modes, not closed mastery.
+- Isolated-worktree controller experiments are not shipped here unless they landed in root `555-mono`.
+- Source of truth remains `555-mono` game code; dossiers are reconciled artifacts, not independent authority.
+
+## 5. Current Report/Evidence Paths That Are Authoritative
+
+- Mastery types: [types.ts](/Volumes/OWC%20Envoy%20Pro%20FX/desktop_dump/new/Work/555/arcade-plugin/src/mastery/types.ts)
+- Shared audit structure: [_shared.ts](/Volumes/OWC%20Envoy%20Pro%20FX/desktop_dump/new/Work/555/arcade-plugin/src/mastery/contracts/_shared.ts)
+- Root mastery export surface: [index.ts](/Volumes/OWC%20Envoy%20Pro%20FX/desktop_dump/new/Work/555/arcade-plugin/src/mastery/index.ts)
+- Root report consumer path at runtime: `/Volumes/OWC Envoy Pro FX/desktop_dump/new/Work/555/milaidy/output/playwright/alice-game-smoke-report.json`
+
+## 6. Known Blockers And Risks
+
+- The audits correctly identify blockers, but they do not close those blockers by themselves.
+- Several controller experiments remain intentionally excluded because they never improved bounded smoke metrics.
+- Root gameplay closure still depends on source-backed controller work in `555-mono`.
+
+## 7. Exact Next Tickets Per Game Or Subsystem
+
+- Regression-only:
+  - `sector-13`
+  - `wolf-and-sheep`
+  - `fighter-planes`
+- Cohort 1:
+  - `PLAYBACK-01`: source-backed `start_room_single_surface_grab_window` setup; patch start-room pre-grab setup only
+  - `FLOOR13-01`: finish-corridor exit-overlap conversion near the final local step; patch local direct-exit first-step conversion only
+  - `CHESS-01`: source-backed checkpoint-1 wedge-window move-selection policy; patch move scoring in rows `48..58`, not route generation broadly
+  - `VEDAS-01`: segment1->segment2 random-platform continuity seam; patch only continuity-state transitions once source-backed
+- Cohort 2:
+  - `NINJA-01`: deterministic level-0 runtime-gap transition policy
+  - `LEFTRIGHT-01`: lane commitment timing and invalidation from source-backed death classes
+  - `CLAWSTRIKE-01`: combat throughput and level-clear sequencing
+  - `ROADS-01`: valid road geometry and distance pacing
+
+## 8. Push/PR Status
+
+- Effective branch remains `main`; no new controller closures were mixed into this handoff batch.
+- Review branch created locally: `codex/pr-atomic-mastery-handoff-arcade-plugin-20260308`
+- Push status at memo creation: pending
+- PR target: `origin/main`
+- PR creation status at memo creation: pending

--- a/docs/handoffs/ATOMIC_MASTERY_HANDOFF_2026-03-08.md
+++ b/docs/handoffs/ATOMIC_MASTERY_HANDOFF_2026-03-08.md
@@ -68,6 +68,6 @@
 
 - Effective branch remains `main`; no new controller closures were mixed into this handoff batch.
 - Review branch created locally: `codex/pr-atomic-mastery-handoff-arcade-plugin-20260308`
-- Push status at memo creation: pending
+- Push status: pushed to `origin/codex/pr-atomic-mastery-handoff-arcade-plugin-20260308`
 - PR target: `origin/main`
-- PR creation status at memo creation: pending
+- PR creation status: open at `https://github.com/rndrntwrk/555-arcade-plugin/pull/1`


### PR DESCRIPTION
## Summary
- cherry-pick the mastery documentation commits onto a clean integration branch
- land the program index, mastery index, progression examples, and exclusion decisions
- make  and  auditable against 
